### PR TITLE
fix types for pvp field on bot

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,5 +9,11 @@ export function plugin(bot: Bot)
     bot.pvp = pvp;
 }
 
+declare module "mineflayer" {
+    interface Bot {
+        pvp: PVP;
+    }
+}
+
 export * from './Cooldown';
 export * from './TimingSolver';

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,8 +4,6 @@ import { PVP } from "./PVP";
 export function plugin(bot: Bot)
 {
     const pvp = new PVP(bot);
-
-    // @ts-expect-error
     bot.pvp = pvp;
 }
 


### PR DESCRIPTION
TS2339: Property 'pvp' does not exist on type 'Bot'.

The module declaration of the fileld fixes that error.