### PR TITLE
Update guard.js to resolve warning

### DIFF
--- a/examples/guard.js
+++ b/examples/guard.js
@@ -71,11 +71,9 @@ bot.on('physicTick', async () => {
   let entity = null
   // Do not attack mobs if the bot is to far from the guard pos
   if (bot.entity.position.distanceTo(guardPos) < 16) {
-    // Only look for mobs within 16 blocks
-   const filter = e => (e.type === 'hostile' || e.type === 'mob') && e.position.distanceTo(bot.entity.position) < 10 && e.mobType !== 'Armor Stand'
-    e.mobType !== 'Armor Stand' // Mojang classifies armor stands as mobs for some reason?
-
-    entity = bot.nearestEntity(filter)
+      // Only look for mobs within 16 blocks
+      const filter = e => (e.type === 'hostile' || e.type === 'mob') && e.position.distanceTo(bot.entity.position) < 10 && e.displayName !== 'Armor Stand' // Mojang classifies armor stands as mobs for some reason?
+      entity = bot.nearestEntity(filter)
   }
   
   if (entity != null && !movingToGuardPos) {


### PR DESCRIPTION
This code remove this warning 
Trace: Warning: entity.mobType is deprecated. Use entity.displayName instead
    at printMobTypeWarning (C:\Users\thiba\downloads\test\node_modules\prismarine-entity\index.js:73:11)
    at get mobType [as mobType] (C:\Users\thiba\downloads\test\node_modules\prismarine-entity\index.js:27:7)
    at filter (C:\Users\thiba\downloads\test\bot.js:169:151)
    at bot.nearestEntity (C:\Users\thiba\downloads\test\node_modules\mineflayer\lib\plugins\entities.js:80:37)
    at Object.<anonymous> (C:\Users\thiba\downloads\test\bot.js:170:34)
    at step (C:\Users\thiba\downloads\test\bot.js:32:23)
    at Object.next (C:\Users\thiba\downloads\test\bot.js:13:53)
    at C:\Users\thiba\downloads\test\bot.js:7:71
    at new Promise (<anonymous>)
    at __awaiter (C:\Users\thiba\downloads\test\bot.js:3:12)